### PR TITLE
The dependency tzinfo-data を解消する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -125,6 +125,3 @@ group :production, :staging do
   # New Relic
   gem 'newrelic_rpm'
 end
-
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
     autoprefixer-rails (9.6.0)
       execjs
     bcrypt (3.1.13)
+    bcrypt (3.1.13-java)
     bindex (0.7.0)
     builder (3.2.3)
     byebug (11.0.1)
@@ -194,6 +195,7 @@ GEM
     faker (1.4.3)
       i18n (~> 0.5)
     ffi (1.11.1)
+    ffi (1.11.1-java)
     fog-aws (3.5.1)
       fog-core (~> 2.1)
       fog-json (~> 1.1)
@@ -239,6 +241,7 @@ GEM
       ruby-vips (>= 2.0.13, < 3)
     ipaddress (0.8.3)
     jaro_winkler (1.5.3)
+    jaro_winkler (1.5.3-java)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -246,6 +249,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.2.0)
+    json (2.2.0-java)
     kakurenbo-puti (0.5.0)
       activerecord (>= 4.1.0)
     kaminari (1.1.1)
@@ -263,6 +267,9 @@ GEM
     kgio (2.11.2)
     launchy (2.4.3)
       addressable (~> 2.3)
+    launchy (2.4.3-java)
+      addressable (~> 2.3)
+      spoon (~> 0.0.1)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -294,8 +301,10 @@ GEM
     net-ssh (5.2.0)
     newrelic_rpm (6.4.0.356)
     nio4r (2.3.1)
+    nio4r (2.3.1-java)
     nokogiri (1.10.3)
       mini_portile2 (~> 2.4.0)
+    nokogiri (1.10.3-java)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
     notiffany (0.1.1)
@@ -311,6 +320,10 @@ GEM
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    pry (0.12.2-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+      spoon (~> 0.0)
     pry-byebug (3.7.0)
       byebug (~> 11.0)
       pry (~> 0.10)
@@ -318,6 +331,7 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.1.0)
     puma (3.12.1)
+    puma (3.12.1-java)
     rack (2.0.7)
     rack-protection (2.0.5)
       rack
@@ -434,6 +448,8 @@ GEM
     sitemap_generator (6.0.2)
       builder (~> 3.0)
     slack-notifier (2.3.2)
+    spoon (0.0.6)
+      ffi
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -451,6 +467,7 @@ GEM
       net-ssh (>= 2.8.0)
     thor (0.20.3)
     thread_safe (0.3.6)
+    thread_safe (0.3.6-java)
     tilt (2.0.9)
     turbolinks (5.2.0)
       turbolinks-source (~> 5.2)
@@ -473,12 +490,16 @@ GEM
     websocket (1.2.8)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
+    websocket-driver (0.7.1-java)
+      websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
     xpath (2.1.0)
       nokogiri (~> 1.3)
 
 PLATFORMS
+  java
   ruby
+  unknown
 
 DEPENDENCIES
   administrate
@@ -538,7 +559,6 @@ DEPENDENCIES
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
-  tzinfo-data
   uglifier (>= 1.3.0)
   unicorn
   web-console (>= 3.3.0)


### PR DESCRIPTION
## issue
https://github.com/iwaseasahi/christchurches-map/issues/283

## 対応したこと
* gem から `tzinfo-data` を外す
* ruby 2.4.6 に上げる