### PR TITLE
rubocop-rails を取り止め

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,2 +1,0 @@
-require:
-  - rubocop-rails

--- a/Gemfile
+++ b/Gemfile
@@ -95,7 +95,7 @@ group :development do
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   # コーディングスタイル
-  gem 'rubocop-rails'
+  gem 'rubocop', require: false
   # capistrano関連
   gem 'capistrano'
   gem 'capistrano-bundler'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,9 +408,6 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
-    rubocop-rails (2.0.1)
-      rack (>= 1.1)
-      rubocop (>= 0.70.0)
     ruby-progressbar (1.10.1)
     ruby-vips (2.0.14)
       ffi (~> 1.9)
@@ -551,7 +548,7 @@ DEPENDENCIES
   redis-namespace
   rmagick
   rspec-rails
-  rubocop-rails
+  rubocop
   sass-rails (~> 5.0)
   selenium-webdriver (~> 2.43.0)
   sidekiq (< 5)


### PR DESCRIPTION
## issue
https://github.com/iwaseasahi/christchurches-map/issues/284

## 対応したこと
`rubocop-rials` を取り止め

## 背景
```
/Users/iwaseasahi/projects/christchurches-map/vendor/bundle/ruby/2.5.0/gems/rubocop-rails-2.0.1/lib/rubocop/cop/rails_cops.rb:7:in `remove_const': constant RuboCop::Cop::Rails not defined (NameError)
```

上記のエラーにより、`bundle exec rails s` が出来なくなったため。