### PR TITLE
Capybara starting Puma... を表示しない

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -85,6 +85,10 @@ RSpec.configure do |config|
     end
   end
 
+  config.before(:all, type: :system) do
+    Capybara.server = :puma, { Silent: true }
+  end
+
   config.before(:each, type: :system) do
     driven_by :rack_test
   end


### PR DESCRIPTION
## issue
resolve  #347

## 対応したこと
puma の logs を出力しないこと