### PR TITLE
deploy を一時停止する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,15 +114,16 @@ workflows:
             branches:
               ignore:
                 - master
-  deploy:
-    jobs:
-      - build:
-          filters:
-            branches:
-              only: master
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: master
+# FIXME: https://github.com/iwaseasahi/christchurches-map/issues/382
+#  deploy:
+#    jobs:
+#      - build:
+#          filters:
+#            branches:
+#              only: master
+#      - deploy:
+#          requires:
+#            - build
+#          filters:
+#            branches:
+#              only: master


### PR DESCRIPTION
## issue
resolve #382

## 対応したこと
手元の mac でサーバに ssh できないため、deploy を一旦停止します。