### PR TITLE
cap deploy の ruby version を変更する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,16 +114,15 @@ workflows:
             branches:
               ignore:
                 - master
-# FIXME: https://github.com/iwaseasahi/christchurches-map/issues/382
-#  deploy:
-#    jobs:
-#      - build:
-#          filters:
-#            branches:
-#              only: master
-#      - deploy:
-#          requires:
-#            - build
-#          filters:
-#            branches:
-#              only: master
+  deploy:
+    jobs:
+      - build:
+          filters:
+            branches:
+              only: master
+      - deploy:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -37,7 +37,7 @@ set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', '
 set :keep_releases, 5
 
 # rubyのバージョン
-set :rbenv_ruby, '2.3.1'
+set :rbenv_ruby, '2.5.5'
 
 # Sidekiq
 # NOTE: https://github.com/seuros/capistrano-sidekiq/issues/124


### PR DESCRIPTION
## issue
resolve  #399

## 対応したこと
* ruby の version を 2.5.5 にしたこと
* deploy を再開したこと
