### PR TITLE
codeclimate を ruby だけにする

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -41,12 +41,10 @@ checks:
     config:
       threshold: #language-specific defaults. overrides affect all languages.
 exclude_patterns:
-- "config/"
-- "db/"
-- "dist/"
-- "features/"
-- "**/node_modules/"
-- "script/"
-- "**/spec/"
-- "**/vendor/"
-- "**/*.d.ts"
+  - 'app/assets/javascripts'
+  - 'app/assets/stylesheets'
+  - 'config/'
+  - 'db/'
+  - 'public/'
+  - 'spec/'
+  - 'vendor/'


### PR DESCRIPTION
## issue
resolve  #482

## 対応したこと
exclude_patterns を実態に合わせたこと
