### PR TITLE
ECS のローリングアップデートの挙動を正しくする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -273,7 +273,6 @@ workflows:
           container-image-name-updates: "container=christchurches-map-rails,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-rails:latest,container=christchurches-map-nginx,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-nginx:latest"
           family: "christchurches-map-task"
           service-name: "christchurches-map-service"
-          skip-task-definition-registration: true
           force-new-deployment: true
           requires:
             - build-ecr-rails


### PR DESCRIPTION
## issue
resolve #810

## 対応したこと

`skip-task-definition-registration` を削除することで、タスク定義のリビジョンをインクリメントします。