### PR TITLE
Revert "circleci - deploy-service-update をリファクタする "

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,21 +208,6 @@ jobs:
           repo: "christchurches-map-nginx"
           skip-when-tags-exist: false
           tag: "latest"
-  deploy-ecs-service-update:
-    executor: default_executor
-    steps:
-      - setup_remote_docker:
-          version: 19.03.13
-          docker_layer_caching: true
-      - aws-ecs/deploy-service-update:
-          aws-access-key-id: AWS_ECS_ACCESS_KEY_ID
-          aws-secret-access-key: AWS_ECS_SECRET_ACCESS_KEY
-          aws-region: AWS_REGION
-          cluster-name: "christchurches-map-cluster"
-          container-image-name-updates: "container=christchurches-map-rails,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-rails:latest,container=christchurches-map-nginx,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-nginx:latest"
-          family: "christchurches-map-task"
-          service-name: "christchurches-map-service"
-
 workflows:
   version: 2
   commit:
@@ -280,7 +265,14 @@ workflows:
           filters:
             branches:
               only: master
-      - deploy-ecs-service-update:
+      - aws-ecs/deploy-service-update:
+          aws-access-key-id: AWS_ECS_ACCESS_KEY_ID
+          aws-secret-access-key: AWS_ECS_SECRET_ACCESS_KEY
+          aws-region: AWS_REGION
+          cluster-name: "christchurches-map-cluster"
+          container-image-name-updates: "container=christchurches-map-rails,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-rails:latest,container=christchurches-map-nginx,image-and-tag=${AWS_ECR_ACCOUNT_URL}/christchurches-map-nginx:latest"
+          family: "christchurches-map-task"
+          service-name: "christchurches-map-service"
           requires:
             - build-ecr-rails
             - build-ecr-nginx


### PR DESCRIPTION
Reverts iwaseasahi/christchurches-map#815

merge したところ、以下のエラーが発生したので revert します。

https://app.circleci.com/pipelines/github/iwaseasahi/christchurches-map/1580/workflows/fc9a4a09-ab8c-4493-acbf-b6752a453748/jobs/3118

```
#!/bin/sh -eo pipefail
# Error calling workflow: 'build-and-deploy-to-ecs'
# Error calling job: 'deploy-ecs-service-update'
# Cannot find a definition for command named aws-ecs/deploy-service-update
# 
# -------
# Warning: This configuration was auto-generated to show you the message above.
# Don't rerun this job. Rerunning will have no effect.
false

Exited with code exit status 1
CircleCI received exit code 1
```