### PR TITLE
Fix gem `selenium-webdriver`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -116,7 +116,7 @@ group :test do
   gem 'rspec-rails'
   gem 'faker'
   gem 'capybara'
-  gem 'selenium-webdriver', git: 'https://github.com/SeleniumHQ/selenium.git', branch: 'rb-3.x'
+  gem 'selenium-webdriver'
   # NOTE: https://github.com/lemurheavy/coveralls-ruby/issues/161
   gem 'simplecov', '< 0.18.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,4 @@
 GIT
-  remote: https://github.com/SeleniumHQ/selenium.git
-  revision: 7af674666e21d72db303d2b90b290b31adf03062
-  branch: rb-3.x
-  specs:
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
-
-GIT
   remote: https://github.com/resque/redis-namespace.git
   revision: 7fd8ad23484e41b07551395098922a1c2f6068af
   branch: master
@@ -85,7 +76,7 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.1)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     administrate (0.18.0)
       actionpack (>= 5.0)
@@ -130,7 +121,7 @@ GEM
       capistrano (~> 3.0)
     capistrano3-unicorn (0.2.1)
       capistrano (~> 3.1, >= 3.1.0)
-    capybara (3.38.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -147,7 +138,6 @@ GEM
       marcel (~> 1.0.0)
       mini_mime (>= 0.1.3)
       ssrf_filter (~> 1.0)
-    childprocess (3.0.0)
     coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
@@ -323,8 +313,8 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2022.0105)
     mini_magick (4.11.0)
-    mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
+    mini_mime (1.1.5)
+    mini_portile2 (2.8.4)
     minitest (5.18.0)
     msgpack (1.6.0)
     msgpack (1.6.0-java)
@@ -348,10 +338,10 @@ GEM
     newrelic_rpm (9.1.0)
     nio4r (2.5.9)
     nio4r (2.5.9-java)
-    nokogiri (1.14.2)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.4)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
-    nokogiri (1.14.2-java)
+    nokogiri (1.15.4-java)
       racc (~> 1.4)
     non-stupid-digest-assets (1.0.9)
       sprockets (>= 2.0)
@@ -378,19 +368,19 @@ GEM
       pry (>= 0.13, < 0.15)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.0)
+    public_suffix (5.0.3)
     puma (6.2.1)
       nio4r (~> 2.0)
     puma (6.2.1-java)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    racc (1.6.2-java)
-    rack (2.2.6.4)
+    racc (1.7.1)
+    racc (1.7.1-java)
+    rack (2.2.8)
     rack-protection (3.0.5)
       rack
     rack-proxy (0.7.6)
       rack
-    rack-test (2.0.2)
+    rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.4.3)
       actioncable (= 7.0.4.3)
@@ -439,13 +429,13 @@ GEM
       railties (>= 3.2)
       tilt
     redis (4.8.1)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.1)
     request_store (1.5.1)
       rack (>= 1.4)
     responders (3.1.0)
       actionpack (>= 5.2)
       railties (>= 5.2)
-    rexml (3.2.5)
+    rexml (3.2.6)
     rmagick (5.2.0)
       pkg-config (~> 1.4)
     rspec (3.11.0)
@@ -503,6 +493,10 @@ GEM
       activerecord (>= 3.1)
       activesupport (>= 3.1)
     selectize-rails (0.12.6)
+    selenium-webdriver (4.11.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
@@ -566,6 +560,7 @@ GEM
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-driver (0.7.5-java)
@@ -635,7 +630,7 @@ DEPENDENCIES
   rubocop-faker
   sass-rails (>= 6)
   seed-fu
-  selenium-webdriver!
+  selenium-webdriver
   sentry-raven
   sidekiq (= 6.5.7)
   simplecov (< 0.18.0)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -27,11 +27,13 @@ ActiveRecord::Migration.maintain_test_schema!
 
 Capybara.register_driver :remote_chrome do |app|
   url = ENV.fetch("SELENIUM_DRIVER_URL")
-  caps = ::Selenium::WebDriver::Remote::Capabilities.chrome("goog:chromeOptions" => {
+  caps = ::Selenium::WebDriver::Remote::Capabilities.new(
+    browser_name: 'chrome',
+    "goog:chromeOptions" => {
       "args" => ["no-sandbox", "headless", "disable-gpu", "window-size=1680,1050"]
     }
   )
-  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+  Capybara::Selenium::Driver.new(app, browser: :remote, url: url, capabilities: caps)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
## issue

以下の CI で落ちている対応をします。
https://app.circleci.com/pipelines/github/iwaseasahi/christchurches-map/3125/workflows/7d7c3de7-b902-4ca4-b669-f3e80222cf42/jobs/6052

## 対応したこと

gem の branch 指定を削除したこと。