### PR TITLE
Fix auto merge dependabot

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,5 +1,10 @@
 name: Dependabot auto-merge
-on: pull_request
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
 
 permissions:
   contents: write
@@ -10,11 +15,21 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
+      - name: Wait for CircleCI to complete
+        id: wait-for-circleci
+        uses: lewagon/wait-on-check-action@v1.1.1
+        with:
+          ref: ${{ github.sha }}
+          check-name: "deploy_check"
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 60
+
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
+
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
## issue

https://app.circleci.com/pipelines/github/iwaseasahi/christchurches-map/3148/workflows/d45224ee-01a6-4156-b34c-77c9b7e65d6c

## 対応したこと

`deploy_check` が完了した後に auto merge を実行すること。