### PR TITLE
unicorn の worker がメモリを消費するので 1 つに減らす

### DIFF
--- a/config/unicorn/production.rb
+++ b/config/unicorn/production.rb
@@ -1,5 +1,5 @@
 # set lets
-$worker  = 2
+$worker  = 1
 $timeout = 30
 $app_dir = '/var/www/projects/christchurches-map/current'
 $listen  = File.expand_path 'tmp/sockets/.unicorn.sock', $app_dir


### PR DESCRIPTION
## issue

#1314

## 対応したこと

unicorn の worker がメモリを消費するので 1 つに減らします。
