### PR TITLE
deploy ブランチに push された場合のみ deploy する

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,6 +151,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - deploy
       - test:
           requires:
             - build
@@ -158,6 +159,7 @@ workflows:
             branches:
               ignore:
                 - master
+                - deploy
       - deploy_check:
           requires:
             - build
@@ -166,15 +168,16 @@ workflows:
             branches:
               ignore:
                 - master
+                - deploy
   deploy:
     jobs:
       - build:
           filters:
             branches:
-              only: master
+              only: deploy
       - deploy:
           requires:
             - build
           filters:
             branches:
-              only: master
+              only: deploy


### PR DESCRIPTION
## issue

#1314

## 対応したこと

deploy ブランチに push された場合のみ deploy します。

これまでは master に push された場合に deploy していましたが、これだと PR をマージする度に deploy するので時間が掛かっていました。

なので、任意のタイミングで deploy できるようにします。